### PR TITLE
Fix downloading files greater than 2.1GB

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -419,9 +419,9 @@ int fetch_remaining_blocks_http(struct zsync_state *z, const char *url,
             return 0;
 
         for(int i=0;i<2*nrange;i++){
-            int beginbyte = zbyterange[i];
+            int64_t beginbyte = zbyterange[i];
             i++;
-            int endbyte = zbyterange[i];
+            int64_t endbyte = zbyterange[i];
             off_t single_range[2] = {beginbyte, endbyte};
             /* And give that to the range fetcher */
             /* Only one range at a time because Akamai can't handle more than one range per request */


### PR DESCRIPTION
I was a bit unsure about where to start, but as far as I can tell this minor change works perfectly. It builds without issue in my default environment, and I've tested as many permutations of functionality as I can think of to download entire files, newer versions of files from old files, older files from newer files, massive files, using multiple local files, interrupting and resuming a download, etc. and my version hasn't failed once.

I don't necessarily feel comfortable with this being merged directly into Master because I'm sure there are better ways of doing it, but at least it works for now and points someone who knows better in the right direction.