### PR TITLE
Add "-j" option to just check for updates without downloading any files

### DIFF
--- a/semistaticbuild.sh
+++ b/semistaticbuild.sh
@@ -31,7 +31,7 @@ export CFLAGS=--std=c99 # zsync_curl does not compile if the compiler is not exp
 ./configure 
 make || true
 
-gcc -g -O2 -g -Wall -Wwrite-strings -Winline -Wextra -Winline -Wmissing-noreturn -Wredundant-decls -Wnested-externs -Wundef -Wbad-function-cast -Wcast-align -Wvolatile-register-var -ffast-math   -o zsync_curl client.o http.o url.o progress.o base64.o libzsync/libzsync.a librcksum/librcksum.a zlib/libinflate.a /usr/local/lib/libcurl.a -lssl -lcrypto -lrt -lm
+gcc -g -O2 -g -Wall -Wwrite-strings -Winline -Wextra -Winline -Wmissing-noreturn -Wredundant-decls -Wnested-externs -Wundef -Wbad-function-cast -Wcast-align -Wvolatile-register-var -ffast-math -pthread -o zsync_curl client.o http.o url.o progress.o base64.o libzsync/libzsync.a librcksum/librcksum.a zlib/libinflate.a /usr/local/lib/libcurl.a -lssl -lcrypto -lrt -lm
 
 strip zsync_curl
 

--- a/src/client.c
+++ b/src/client.c
@@ -555,12 +555,13 @@ int main(int argc, char **argv) {
     time_t mtime;
 
     int printRedirect = 0;
+    int justCheckForUpdates = 0;
 
     srand(getpid());
     {   /* Option parsing */
         int opt;
 
-        while ((opt = getopt(argc, argv, "r:c:k:o:i:VIsqu:")) != -1) {
+        while ((opt = getopt(argc, argv, "r:c:k:o:i:VIsqju:")) != -1) {
             switch (opt) {
             case 'k':
                 free(zfname);
@@ -593,6 +594,9 @@ int main(int argc, char **argv) {
                 break;
             case 'r':
                 printRedirect = 1;
+                break;
+            case 'j':
+                justCheckForUpdates = 1;
                 break;
             }
         }
@@ -676,6 +680,23 @@ int main(int argc, char **argv) {
                 fputs
                     ("No relevent local data found - I will be downloading the whole file. If that's not what you want, CTRL-C out. You should specify the local file is the old version of the file to download with -i (you might have to decompress it with gzip -d first). Or perhaps you just have no data that helps download the file\n",
                      stderr);
+        }
+    }
+
+    /* In case the user just wants to check whether there is an update available,
+     * report with the exit code the result:
+     *      0 if file is already updated
+     *      1 if file needs to be updated
+     */
+    if (justCheckForUpdates) {
+        if (zsync_status(zs) >= 2) {
+            if (!no_progress)
+                printf("There is no need to download new data\n");
+            exit(0);
+        } else {
+            if (!no_progress)
+                printf("File is outdated. New data needs to be downloaded\n");
+            exit(1);
         }
     }
 

--- a/src/libzsync/zsync.c
+++ b/src/libzsync/zsync.c
@@ -117,7 +117,6 @@ struct zsync_state {
 static int zsync_read_blocksums(struct zsync_state *zs, FILE * f,
                                 int rsum_bytes, int checksum_bytes,
                                 int seq_matches);
-static int zsync_sha1(struct zsync_state *zs, int fh);
 static int zsync_recompress(struct zsync_state *zs);
 static time_t parse_822(const char* ts);
 
@@ -597,7 +596,7 @@ int zsync_complete(struct zsync_state *zs) {
  * target, read it and compare the SHA1 checksum with the one from the .zsync.
  * Returns -1 or 1 as per zsync_complete.
  */
-static int zsync_sha1(struct zsync_state *zs, int fh) {
+int zsync_sha1(struct zsync_state *zs, int fh) {
     SHA1_CTX shactx;
 
     {                           /* Do SHA1 of file contents */

--- a/src/libzsync/zsync.h
+++ b/src/libzsync/zsync.h
@@ -72,6 +72,13 @@ off_t* zsync_needed_byte_ranges(struct zsync_state* zs, int* num, int type);
  * Returns -1 for failure, 1 for success, 0 for unable to verify (e.g. no checksum in the .zsync) */
 int zsync_complete(struct zsync_state* zs);
 
+/* zsync_sha1(self, filedesc)
+ * Given the currently-open-and-at-start-of-file complete local copy of the
+ * target, read it and compare the SHA1 checksum with the one from the .zsync.
+ * Returns -1 or 1 as per zsync_complete.
+ */
+int zsync_sha1(struct zsync_state *zs, int fh);
+
 /* Clean up and free all resources. The pointer is freed by this call.
  * Returns a strdup()d pointer to the name of the file resulting from the process. */
 char* zsync_end(struct zsync_state* zs);

--- a/staticbuild.sh
+++ b/staticbuild.sh
@@ -48,7 +48,7 @@ make || true
 # If we had built wolfssl without the "--disable-shared" above, we could now 
 # use libwolfssl.so instead of libwolfssl.a and get a dependency on libwolfssl.so
 # which would save around 300K in the binary but add a 400K dependency
-gcc -g -O2 -g -Wall -Wwrite-strings -Winline -Wextra -Winline -Wmissing-noreturn -Wredundant-decls -Wnested-externs -Wundef -Wbad-function-cast -Wcast-align -Wvolatile-register-var -ffast-math   -o zsync_curl client.o http.o url.o progress.o base64.o libzsync/libzsync.a librcksum/librcksum.a zlib/libinflate.a /usr/local/lib/libcurl.a /usr/local/lib/libwolfssl.a -lrt -lm
+gcc -g -O2 -g -Wall -Wwrite-strings -Winline -Wextra -Winline -Wmissing-noreturn -Wredundant-decls -Wnested-externs -Wundef -Wbad-function-cast -Wcast-align -Wvolatile-register-var -ffast-math -pthread -o zsync_curl client.o http.o url.o progress.o base64.o libzsync/libzsync.a librcksum/librcksum.a zlib/libinflate.a /usr/local/lib/libcurl.a /usr/local/lib/libwolfssl.a -lrt -lm
 
 strip zsync_curl
 


### PR DESCRIPTION
This argument is meant to be used whenever the user simply wants to check whether there is a new version available, without starting the update.

The reason to have this parameter is for the following use case while using it along with an AppImage:

1. An application wants to know whether there is a new update, without downloading new files
2. Call zsync_curl and depending on its exit code, the application knows whether new data needs to be downloaded
3. Depending on the previous result, show the user there is a new update available
4. In case the user confirms the update, call the appimageupdate tool (with or without GUI) that will call zsync_curl to download the new data

I am not sure if the place where I added the logic is the best one for this or this could be done even earlier. Please provide feedback also for the output shown to the user and feel free to add/modify as needed.
