### PR TITLE
Skip reading the block sums in case we just want to check for updates

### DIFF
--- a/src/libzsync/zsync.c
+++ b/src/libzsync/zsync.c
@@ -137,7 +137,7 @@ static char **append_ptrlist(int *n, char **p, char *a) {
 }
 
 /* Constructor */
-struct zsync_state *zsync_begin(FILE * f) {
+struct zsync_state *zsync_begin(FILE * f, int readBlockSums) {
     /* Defaults for the checksum bytes and sequential matches properties of the
      * rcksum_state. These are the defaults from versions of zsync before these
      * were variable. */
@@ -307,9 +307,12 @@ struct zsync_state *zsync_begin(FILE * f) {
         free(zs);
         return NULL;
     }
-    if (zsync_read_blocksums(zs, f, rsum_bytes, checksum_bytes, seq_matches) != 0) {
-        free(zs);
-        return NULL;
+
+    if (readBlockSums) {
+        if (zsync_read_blocksums(zs, f, rsum_bytes, checksum_bytes, seq_matches) != 0) {
+            free(zs);
+            return NULL;
+        }
     }
     return zs;
 }

--- a/src/libzsync/zsync.h
+++ b/src/libzsync/zsync.h
@@ -16,8 +16,9 @@
 struct zsync_state;
 
 /* zsync_begin - load a zsync file and return data structure to use for the rest of the process.
+ * readBlockSums should be 0 whenever we just want to parse the zsync file
  */
-struct zsync_state* zsync_begin(FILE* cf);
+struct zsync_state* zsync_begin(FILE* cf, int readBlockSums);
 
 /* zsync_hint_decompress - if it returns non-zero, this suggests that 
  *  compressed seed files should be decompressed */


### PR DESCRIPTION
I noticed that the `rcksum-*` files were still been created every single time we were using the `-j` flag to check for new versions. Even if they are empty, I realized we were doing quite a lot of extra work not needed when using this flag.

Hence, I have added a new parameter when calling `read_zsync_control_file` to skip doing this extra work in case `-j` is passed. This also improves quite a lot the performance for big files, since now all we are doing is parsing the `.zsync` file and checking the SHA1 hash of the whole file.

I also changed the exit value in case the file does not exist to distinguish it from the case where it needs to be updated.