### PR TITLE
Update README to include devscripts as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git clone https://github.com/AppImage/zsync-curl.git
 To build a deb:
 
 ```
-sudo apt-get -y install autotools-dev libcurl4-openssl-dev git debhelper
+sudo apt-get -y install autotools-dev libcurl4-openssl-dev git debhelper devscripts
 git clone https://github.com/AppImage/zsync-curl.git
 cd ./zsync-curl/src
 debuild -i -us -uc -b


### PR DESCRIPTION
Current instructions for building deb will throw `debuild not found`.