### PR TITLE
PR-35 Include strings.h header.

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 #include <errno.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Missing include required for MacOS compilation.